### PR TITLE
reconfigure api endpoint

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -36,7 +36,7 @@ app.use(bodyParser.urlencoded({
 }))
 
 // set endpoints
-app.get('/machines', db.getMachines)
+app.get('/api/machines', db.getMachines)
 
 // start server
 app.listen(port, (request, response) => {


### PR DESCRIPTION
- reconfigure api endpoint to `/api/machines` instead of `/machines` to avoid confusion with client-side route