### PR TITLE
machines(fix): only display certain fields

### DIFF
--- a/server/controllers/machines.js
+++ b/server/controllers/machines.js
@@ -27,7 +27,7 @@ module.exports = {
   list(request, response) {
     return models.machines
       .findAll({
-        attributes: ['name', 'size', 'origin', 'override', 'machine_class', 'machine_sites', 'weakness', 'strength', 'weak_points', 'id', 'created_at', 'updated_at']
+        attributes: ['name', 'size', 'origin', 'override', 'machine_class', 'machine_sites', 'weakness', 'strength', 'weak_points']
       })
       .then(machines => response.status(200).send(machines))
       .catch(error => response.status(400).send(error.message))

--- a/server/server.js
+++ b/server/server.js
@@ -11,18 +11,6 @@ const cors = require('cors');
 
 app.use(cors())
 
-// whitelist for cors
-const whitelist = ['http://hzd-website.herokuapp.com/', 'http://localhost:3000/']
-const corsOptions = {
-  origin: (origin, callback) => {
-    if (whitelist.indexOf(origin) !== -1) {
-      callback(null, true)
-    } else {
-      callback(new Error('Not allowed by CORS'))
-    }
-  }
-}
-
 app.use(express.static(path.resolve(__dirname, '../client/build')));
 
 // enable CORS


### PR DESCRIPTION
- exclude the following fields when rendering the data table
    - `id`
    - `created_at`
    - `updated_at`
- closes #58 