### PR TITLE
machines(fix): fix search filter

### DIFF
--- a/client/src/components/Machines/Machines.js
+++ b/client/src/components/Machines/Machines.js
@@ -25,7 +25,7 @@ const Machines = () => {
           let values = Object.values(machine); // get values of each machine object
 
           for (let value of values) {
-            if(value.toString().toLowerCase().includes(search)) {
+            if(value !== null && value.toString().toLowerCase().includes(search)) {
               // if any of the values include the search term, push the machine into the filteredMachines array
               filteredMachines.push(machine);
               break; // break out of the loop as soon as the condition is met the first time

--- a/client/src/components/Template/Table.js
+++ b/client/src/components/Template/Table.js
@@ -12,7 +12,7 @@ const TableRow = ({ tableCells }) => {
 
 const Table = ({ headers, data }) => {
   return (
-    <table className='table'>
+    <table className='table is-fullwidth'>
       <thead>
         <tr>
           {headers.map((header, index) => (

--- a/client/src/styles/variables.scss
+++ b/client/src/styles/variables.scss
@@ -57,13 +57,9 @@ $navbar-dropdown-background-color: $blue;
 
 // pages for machines, login, add machine
 .machines-section {
-  height: auto;
+  min-height: 100vh;
   width: 90vw;
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  justify-content: center;
-  margin: 2rem auto;
+  margin: 5rem auto;
 }
 
 .login-section {


### PR DESCRIPTION
- fix bug with search bar filter caused by using `toString` on null values (null values were a result of adding `explosive_components` after machines have already been added)
- closes #85 