### PR TITLE
app(fix): fix page content error

### DIFF
--- a/client/static.json
+++ b/client/static.json
@@ -1,0 +1,7 @@
+{
+  "root": "build/",
+  "clean_urls": false,
+  "routes": {
+    "/**": "index.html"
+  }
+}


### PR DESCRIPTION
- fix page content error when reloading the page or entering the url manually by adding a `static.json` file in `/client/static.json` to declare the routes
- closes #90 