### PR TITLE
server(fix): remove unused auth dependency

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -11,8 +11,6 @@ const port = process.env.PORT || 8080
 
 const cors = require("cors")
 
-require("./auth/auth")
-
 app.use(cors())
 app.use(history())
 


### PR DESCRIPTION
- remove unused `auth` dependency (directory was already deleted) which caused on `Application Error` on `Heroku`